### PR TITLE
Fix bugs in Reminder feature

### DIFF
--- a/Constant.hpp
+++ b/Constant.hpp
@@ -37,7 +37,7 @@ const int TAG_ITEM_VCH_CFT = 642;
 const int TAG_FUNC_VCH_CTL = 650;
 
 const int TAG_ITEM_VCH_REM = 340;
-const int TAG_ITEM_VCH_SRM = 340;
+const int TAG_ITEM_VCH_SRM = 341;
 const int TAG_FUNC_VCH_REM = 346;
 
 const int SYNC_REQUEST = 100;

--- a/requestMenu.cpp
+++ b/requestMenu.cpp
@@ -88,11 +88,11 @@ CVCHPlugin::CVCHPlugin() : EuroScopePlugIn::CPlugIn(EuroScopePlugIn::COMPATIBILI
 			distanceCFT = atof(settingLoad);
 	}
 	if ((settingLoad = GetDataFromSettings("vch_rem")) != NULL) {
-		if (settingLoad != "")
+		if (strcmp(settingLoad, "") != 0)
 			reminderSymbol = settingLoad;
 	}
 	if ((settingLoad = GetDataFromSettings("vch_nrm")) != NULL) {
-		if (settingLoad != "")
+		if (strcmp(settingLoad, "") != 0)
 			reminderSymbolOff = settingLoad;
 	}
 	/*if ((settingLoad = GetDataFromSettings("vch_rto")) != NULL) {
@@ -1038,7 +1038,7 @@ void CVCHPlugin::switchReminder(CFlightPlan* flightPlan) {
 }
 
 bool CVCHPlugin::hasReminder(CFlightPlan* flightPlan) {
-	if (flightPlan->GetControllerAssignedData().GetFlightStripAnnotation(TAG_STRIP_ANNO_REM) == "REM") {
+	if (strcmp(flightPlan->GetControllerAssignedData().GetFlightStripAnnotation(TAG_STRIP_ANNO_REM), "REM") == 0) {
 		return true;
 	} else {
 		return false;


### PR DESCRIPTION
* Strings with type `char *` should be compared with `strcmp()` instead of `==`
* Same Tag Item ID between 'Reminder' and 'Reminder only when active'